### PR TITLE
add the ability to unload keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ configuration.
      -v, --version         display version
      -d, --defer           defer adding keys until the next envoy invocation
      -a, --add             add private key identities
+     -x, --expunge         remove private key identities
      -k, --kill            kill the running agent
      -r, --reload          reload the agent (gpg-agent only)
      -l, --list            list fingerprints of all loaded identities


### PR DESCRIPTION
This adds a convenient way to remove keys. It's actually just a wrapper to `ssh-add -d`, just like how `envoy -a` is actually just a wrapper to `ssh-add`.

I'm not really sure that `-x` or `--expunge` is really the best option name, but the obvious choice of `-d` was already taken.

If this seems totally useless let me know. I'm in an environment where I want to be able to easily unload keys, because I have to regularly ssh to hosts with agent forwarding that I don't trust. To do this, I have some shell scripts that manage which keys I have loaded in my agent. This is obviously achievable with just `ssh-agent`, but doing it all from envoy seems to make sense to me.