### PR TITLE
fix ignore pattern for gpg-protocol.c

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 /envoyd
 /envoy-exec
 /pam_envoy.so
-/gpg-protocol.c
+src/gpg-protocol.c
 *.o
 *.pyc
 __pycache__/


### PR DESCRIPTION
This fixes the gitignore pattern for the generated `gpg-protocol.c` for me (on git 2.4.2). I'm not sure if this is working for you or what, but this change also seems to reflect the docs at http://git-scm.com/docs/gitignore , to wit:
> These patterns match relative to the location of the .gitignore file.

So as I understand it, `/gpg-protocol.c` will only match that file if it's found in the root directory of the project, but not if it's found in the `src/` directory.

¯\\\_(ツ)_/¯