### PR TITLE
s/prefered/preferred agent/ in all of the places

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ configuration.
      -s, --sh              print sh style commands
      -c, --csh             print csh style commands
      -f, --fish            print fish style commands
-     -t, --agent=AGENT     set the prefered to start
+     -t, --agent=AGENT     set the preferred agent to start
 
 Note that when passing in keys, if they reside in `~/.ssh/`, then just
 providing the filename is sufficient.

--- a/src/envoy.c
+++ b/src/envoy.c
@@ -227,7 +227,7 @@ static _noreturn_ void usage(FILE *out)
         " -s, --sh              print sh style commands\n"
         " -c, --csh             print csh style commands\n"
         " -f, --fish            print fish style commands\n"
-        " -t, --agent=AGENT     set the preferred to start\n", out);
+        " -t, --agent=AGENT     set the preferred agent to start\n", out);
 
     exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
 }

--- a/zsh-completion
+++ b/zsh-completion
@@ -16,13 +16,13 @@ envoy)
     {-s,--sh}'[print sh style commands]' \
     {-c,--csh}'[print csh style commands]' \
     {-f,--fish}'[print fish style commands]' \
-    {-t,--agent=-}'[set the prefered to start]:agents:(ssh-agent gpg-agent)'
+    {-t,--agent=-}'[set the preferred agent to start]:agents:(ssh-agent gpg-agent)'
   ;;
 envoyd)
   _arguments -s \
     {-h,--help}'[display this help]'\
     {-v,--version}'[display version]'\
-    {-t,--agent=-}'[set the prefered to start]:agents:(ssh-agent gpg-agent)'
+    {-t,--agent=-}'[set the preferred agent to start]:agents:(ssh-agent gpg-agent)'
   ;;
 envoy-exec)
   _arguments -s '*::arguments: _normal'


### PR DESCRIPTION
Earlier commit 005fdebb4bf79f38adc3ae0e8d64aa5c4614d0c5 started fixing this misspelling, but it persisted in the README and zsh-completion; also, "preferred" is a transitive verb, so it should be "preferred agent".